### PR TITLE
Fix: Add missing data variable to commented swap function call

### DIFF
--- a/src/content/docs/tutorials/match-3/part1.mdx
+++ b/src/content/docs/tutorials/match-3/part1.mdx
@@ -611,7 +611,7 @@ each {|entity: Entity, data: Data|
 +        if(selected.x == grid_mouse.x && selected.y == grid_mouse.y) {
 +          data.selected = [-1, -1]
 +        } else if(allow_swap) {
-+          // swap(selected.x, selected.y, grid_mouse.x, grid_mouse.y)
++          // swap(data, selected.x, selected.y, grid_mouse.x, grid_mouse.y)
 +          data.selected = [-1, -1]
 +        }
 +      } else {
@@ -651,7 +651,8 @@ complete_swap(data: Data, x1: Num, y1: Num, x2: Num, y2: Num) {
 }
 ```
 
-Here's what that looks like now:   
+You can now uncomment the previous `swap` function call in tick.
+Here's what swapping looks like now:   
 
 <Video src="/video/tutorials/match3/swap.mp4" />
 


### PR DESCRIPTION
The match-3 tutorial has a tiny stumbling block, where the swap call that you're provided in the tick function is missing the `data` variable at the front, so if you carelessly un-comment it and try to build the game, it errors when you do your first swap.

This change ensures the commented code works immediately after un-commenting it. Additionally, it adds a call to action to un-comment the code after adding the `swap` & `complete_swap` definitions.